### PR TITLE
homework1

### DIFF
--- a/src/main/java/ru/geekbrains/client/Client.java
+++ b/src/main/java/ru/geekbrains/client/Client.java
@@ -59,6 +59,46 @@ public class Client extends JFrame {
 
 	private void getFile(String filename) {
 		// TODO: 13.05.2021 downloading
+		try {
+			File file = new File("client/" + filename);
+			if (!file.exists()) {
+				file.createNewFile();
+			}
+
+			FileOutputStream fos = new FileOutputStream(file);
+
+			out.writeUTF("download");
+			out.writeUTF(filename);
+
+			byte[] buffer = new byte[8 * 1024];
+			int size;
+			while ((size = in.readInt()) > 0) {
+				in.readFully(buffer, 0, size);
+				fos.write(buffer, 0, size);
+			}
+
+			fos.close();
+
+			// -1 is code error file not found
+			if (size != -1) {
+				String status = "OK";
+				out.writeUTF(status);
+				System.out.println("Getting status: " + status);
+
+			} else {
+				System.err.println("File not found - /server/" + filename);
+				file.delete();
+			}
+
+			in.readUTF();            // Read command
+		} catch (IOException e) {
+			try {
+				out.writeUTF("WRONG");
+			} catch (IOException ioException) {
+				ioException.printStackTrace();
+			}
+			e.printStackTrace();
+		}
 	}
 
 	private void sendFile(String filename) {

--- a/src/main/java/ru/geekbrains/server/ClientHandler.java
+++ b/src/main/java/ru/geekbrains/server/ClientHandler.java
@@ -24,6 +24,7 @@ public class ClientHandler implements Runnable {
 				}
 				if ("download".equals(command)) {
 					// TODO: 13.05.2021 downloading
+					downloading(out, in);
 				}
 				if ("exit".equals(command)) {
 					out.writeUTF("DONE");
@@ -40,6 +41,44 @@ public class ClientHandler implements Runnable {
 		catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	private void downloading(DataOutputStream out, DataInputStream in) throws IOException {
+		String filename = "";
+		String status;
+
+		try {
+			filename = in.readUTF();
+			File file = new File("server/" + filename);
+			if (!file.exists()) {
+				throw new FileNotFoundException();
+			}
+
+			FileInputStream fis = new FileInputStream(file);
+
+			int read = 0;
+			byte[] buffer = new byte[8 * 1024];
+			while ((read = fis.read(buffer)) != -1) {
+				out.writeInt(read);
+				out.write(buffer, 0, read);
+			}
+
+			out.writeInt(0);					// End of file download
+
+			out.flush();
+			fis.close();
+
+			status = in.readUTF();
+
+		} catch (FileNotFoundException e) {
+			out.writeInt(-1);				// code error file not found
+			status = "WRONG";
+			System.err.println("File not found - /server/" + filename);
+		} catch (IOException e) {
+			status = "WRONG";
+		}
+
+		System.out.println("Downloading status: " + status);
 	}
 
 	private void uploading(DataOutputStream out, DataInputStream in) throws IOException {


### PR DESCRIPTION
Добрый день.
Столкнулся с проблемой при использовании алгоритма рассмотренного на уроке (использовал Java 8). В моем случае клиент читал байты из потока быстрее чем их успевал записывать сервер. Это приводило к тому что клиент считывал не полный буфер и передаваемый файл получался битым. При запуске клиента в отладчике все работало хорошо, если устанавливать задержку клиенту хотя бы на секунду перед тем как он начнет читать байты, сервер успевал наполнить поток и передача файла завершалась корректно.
Для решения проблемы изменил алгоритм передачи. Клиенту передается не общий размер файла, а размер каждой части и клиент считывает буфер целиком in.readFully(buffer, 0, size);. 
На сервере в конце цикла while (true), который слушает команды от клиента, есть команда out.writeUTF(command);. Это как раз те лишние байты про которые кто-то спрашивал во время второго урока. Что бы они не мешали при повторном выполнении загрузки на клиенте в конце метода загрузки добавил строку in.readUTF();, которая (как бы) очищает поток.
